### PR TITLE
Setting array key for related posts query based upon mlt

### DIFF
--- a/features/related-posts/related-posts.php
+++ b/features/related-posts/related-posts.php
@@ -28,13 +28,19 @@ function ep_related_posts_formatted_args( $formatted_args, $args ) {
 			$ids = is_array( $args[ 'more_like' ] ) ? $args[ 'more_like' ] : array( $args[ 'more_like' ] );
 		}
 
+		$mlt_key = ( $new_mlt ) ? 'like' : 'ids';
+
 		$formatted_args[ 'query' ] = array(
 			'more_like_this' => array(
-				'ids'			  => $ids,
-				'fields'		  => apply_filters( 'ep_related_posts_fields', array( 'post_title', 'post_content', 'terms.post_tag.name' ) ),
-				'min_term_freq'	  => 1,
+				$mlt_key          => $ids,
+				'fields'          => apply_filters( 'ep_related_posts_fields', array(
+					'post_title',
+					'post_content',
+					'terms.post_tag.name'
+				) ),
+				'min_term_freq'   => 1,
 				'max_query_terms' => 12,
-				'min_doc_freq'	  => 1,
+				'min_doc_freq'    => 1,
 			)
 		);
 	}

--- a/tests/features/test-related-posts.php
+++ b/tests/features/test-related-posts.php
@@ -67,10 +67,12 @@ class EPTestRelatedPostsFeature extends EP_Test_Base {
 
 		$related = ep_find_related( $post_id );
 		$this->assertEquals( 1, sizeof( $related ) );
+		$this->assertTrue( isset( $related[0] ) && isset( $related[0]->elasticsearch ) );
 
 		add_filter( 'ep_find_related_args', array( $this, 'find_related_posts_filter' ), 10, 1 );
 		$related = ep_find_related( $post_id );
 		$this->assertEquals( 2, sizeof( $related ) );
+		$this->assertTrue( isset( $related[0] ) && isset( $related[0]->elasticsearch ) );
 		remove_filter( 'ep_find_related_args', array( $this, 'find_related_posts_filter' ), 10, 1 );
 	}
 	


### PR DESCRIPTION
@oscarssanchez can you test this out and see if this works.

This is in regard to: https://github.com/10up/ElasticPress/pull/1146